### PR TITLE
2.0.1 Update

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,11 @@
 # CustomDeathMessages
 
-<b>CustomDeathMessages</b> is a highly customizable, cross version plugin that allows you to edit any death message in the game. It comes with default messages, which you can modify, delete, or add to. Install the plugin, and everything is all set to go! Plugin works on all versions 1.8+.
+<b>CustomDeathMessages</b> is a highly customizable, cross version plugin that allows you to edit any death message in
+the game. It comes with default messages, which you can modify, delete, or add to. Install the plugin, and everything is
+all set to go! Plugin works on all versions 1.8+.
 
 ### Features
+
 Edit every death message in the game!
 Toggleable and configurable global death messages.
 Toggleable hover event that displays the original message.
@@ -19,358 +22,369 @@ Extensive and very customizable config, see the example below.
 ### Commands and Permissions
 
 * The path argument autocompletes, so no need to go looking in config.
-/cdm reload - Reloads the config after making a change.
-  * permission: cdm.reload
+  /cdm reload - Reloads the config after making a change.
+    * permission: cdm.reload
 
 * /cdm add <path> [new message] - Adds messages to config.
-  * permission: cdm.modify
+    * permission: cdm.modify
 
-* /cdm list <path> - Lists the messages for a death message cause, and lists their index which allows you to delete specific messages.
-  * permission: cdm.list
+* /cdm list <path> - Lists the messages for a death message cause, and lists their index which allows you to delete
+  specific messages.
+    * permission: cdm.list
 
-* /cdm remove <path> <index> - Deletes messages from config. The index is the number of the message you want to delete, obtained by '/cdm list <path>'.
-  * permission: cdm.modify
+* /cdm remove <path> <index> - Deletes messages from config. The index is the number of the message you want to delete,
+  obtained by '/cdm list <path>'.
+    * permission: cdm.modify
 
 * /cdm set flag <path> <true|false> - Toggles features in config.
-  * permission: cdm.modify
+    * permission: cdm.modify
 
 * /cdm set message <path> <message> - Sets string messages in config.
-  * permission: cdm.modify
+    * permission: cdm.modify
 
 * /cdm set number <path> <number> -Sets number values in config.
-  * permission: cdm.modify
+    * permission: cdm.modify
 
 ### Update Checker
+
 * permission: cdm.updates
 * allows players with this permission to receive a message when a plugin update is available.
 
 ### Config
-```yaml
 
-# Enable Update Messages: Toggles update messages on or off.
+```yaml
+# Enable Update Messages: enables update messages
 enable-update-messages: true
 
 # To use hex colors: &#hex
-# PvP Messages only for when a player is killed by another player, enabled by default
+# PvP Messages: sends a message to the killer and victim when a player is killed by another player.
 # Placeholders for pvp messages: %victim%, %victim-nick%, %killer%, %killer-nick%, %killer-x%, %killer-y%, %killer-z%, %victim-x%, %victim-y%, %victim-z%
 enable-pvp-messages: true
 killer-message: '&e[&cDeathMessages&e] &eYou killed &c%victim%'
 victim-message: '&e[&cDeathMessages&e] &eYou were killed by &c%killer%'
 
-# Toggleable features: set true to enable, false to disable. All features except lightning-effect are false by default.
-# Drop Head Percentage: self-explanatory, chance of a player head to drop
-# Do Lightning: creates a lightning effect that will not harm or damage anything when the victim is killed. True by default.
-# Head Name: Sets the name of a head whenever dropped from a player.
-head-name: "&c%victim%'s Head"
-do-lightning: true
+# Lightning: lightning strike effect at the location of the death.
+enable-lightning: true
 
-# Number between 0 and 1 (0 = 0%, 0.5 = 50%, 1 = 100%)
+# Drop head percentage: chance to drop head, should be a number between 0 and 1: (0 = 0%, 0.5 = 50%, 1 = 100%)
+# Head name: name of the head whenever dropped from a player.
 drop-head-percentage: 0.5
+head-name: "&c%victim%'s Head"
+
+# Message cooldown: cooldown in seconds between death messages for a specific player. 0 to disable.
+message-cooldown: 0
 
 # Enable Global Messages: enables global death messages
 enable-global-messages: true
 
-# Original Hover Message: Show the original death message when hovering over the custom message.
-original-hover-message: false
+# Original on Hover: show the original death message when hovering over the custom message.
+enable-original-on-hover: false
 
-# You can add messages or remove any of these messages. Toggleable by boolean above.
+# Item on Hover: show the item used to kill the player when hovering over the item name.
+enable-item-on-hover: true
+
+# You can add, edit, or remove any of the messages below.
 # Placeholders for melee messages: %kill-weapon%, %victim%, %victim-nick%, %killer%, %killer-nick%, %killer-x%, %killer-y%, %killer-z%, %victim-x%, %victim-y%, %victim-z%
-# Enable Item Hover: When hovering over the kill-weapons name, it will display the items enchantments, etc.
-enable-item-hover: false
 global-pvp-death-messages:
-- "&c%victim% &ehas been killed by &c%killer%"
-- "&c%victim% &ewas slain by &c%killer% &eusing &7[&b%kill-weapon%&7]"
-- "&c%victim% &ehas been put down by &c%killer%"
-- "&c%victim% &ewas slaughtered by &c%killer% &eusing &7[&b%kill-weapon%&7]"
-- "&c%killer% &epulverized &c%victim% &eusing &7[&b%kill-weapon%&7]"
-- "&c%victim% &ewas destroyed by &c%killer%&e"
-- "&c%killer% &egave &c%victim% &ethe L"
-- "&c%victim% &ewas EZ clapped by &c%killer% &eusing &7[&b%kill-weapon%&7]"
+  - "&c%victim% &ehas been killed by &c%killer%"
+  - "&c%victim% &ewas slain by &c%killer% &eusing &7[&b%kill-weapon%&7]"
+  - "&c%victim% &ehas been put down by &c%killer%"
+  - "&c%victim% &ewas slaughtered by &c%killer% &eusing &7[&b%kill-weapon%&7]"
+  - "&c%killer% &epulverized &c%victim% &eusing &7[&b%kill-weapon%&7]"
+  - "&c%victim% &ewas destroyed by &c%killer%&e"
+  - "&c%killer% &egave &c%victim% &ethe L"
+  - "&c%victim% &ewas EZ clapped by &c%killer% &eusing &7[&b%kill-weapon%&7]"
 
 # Placeholders for melee messages: %victim%, %victim-nick%, %killer%, %killer-nick%, %killer-x%, %killer-y%, %killer-z%, %victim-x%, %victim-y%, %victim-z%
 melee-death-messages:
-- "&c%victim% &ewas slapped by &c%killer%"
-- "&c%victim% &ewas KO'd &c%killer%"
-- "&c%victim% &egot rocked by &c%killer%"
+  - "&c%victim% &ewas slapped by &c%killer%"
+  - "&c%victim% &ewas KO'd &c%killer%"
+  - "&c%victim% &egot rocked by &c%killer%"
 
-# Messages for entities with custom names. Will override their mob group message and display these instead, if enabled.
+# Messages for entities with custom names: will override their mob group message and display these instead, if enabled.
 # Placeholders: %victim%, %victim-nick%, %entity-name%, %victim-x%, %victim-y%, %victim-z%
 enable-custom-name-entity-messages: true
 custom-name-entity-messages:
-- "&c%victim% &egot rocked by %entity-name%"
-- "&c%victim% &ewas put to sleep by %entity-name%"
-- "%entity-name% &eate &c%victim%'s &esoul"
-- "&c%victim% &ewishes they didn't fight %entity-name%"
+  - "&c%victim% &egot rocked by %entity-name%"
+  - "&c%victim% &ewas put to sleep by %entity-name%"
+  - "%entity-name% &eate &c%victim%'s &esoul"
+  - "&c%victim% &ewishes they didn't fight %entity-name%"
 
 # Placeholders for ALL below messages: %victim%, %victim-nick%, %entity-name%, %victim-x%, %victim-y%, %victim-z%
 fall-damage-messages:
-- "&c%victim% &emade themself a pancake on the ground"
-- "&c%victim% &efell from a high spot"
+  - "&c%victim% &emade themself a pancake on the ground"
+  - "&c%victim% &efell from a high spot"
 
 drowning-messages:
-- "&c%victim% &efound out the hard way they don't have gills"
-- "&c%victim% &ethought they could make it to oxygen in time"
+  - "&c%victim% &efound out the hard way they don't have gills"
+  - "&c%victim% &ethought they could make it to oxygen in time"
 
 suffocation-messages:
-- "&c%victim% &ecouldn't catch their breath while in a block"
-- "&c%victim% &ecouldn't breathe while inside of a block"
+  - "&c%victim% &ecouldn't catch their breath while in a block"
+  - "&c%victim% &ecouldn't breathe while inside of a block"
 
 cramming-messages:
-- "&c%victim% &egot crushed and couldn't breathe"
-- "&ePoor &c%victim%&e, they thought they could live in a 1x1 space"
+  - "&c%victim% &egot crushed and couldn't breathe"
+  - "&ePoor &c%victim%&e, they thought they could live in a 1x1 space"
 
 thorns-messages:
-- "&c%victim% &egot karma'd by &c%killer%'s &ethorns"
-- "&c%victim% &egot the tables turned on them by &c%killer%'s &ethorns"
+  - "&c%victim% &egot karma'd by &c%killer%'s &ethorns"
+  - "&c%victim% &egot the tables turned on them by &c%killer%'s &ethorns"
 
 lava-messages:
-- "&c%victim% &eburned up in a pit of lava"
-- "&c%victim% &efell into a lava pool... say goodbye to his items"
+  - "&c%victim% &eburned up in a pit of lava"
+  - "&c%victim% &efell into a lava pool... say goodbye to his items"
 
 magma-block-messages:
-- "&c%victim% &ewas removed by a hot &6&lmagma block... &ejust crouch?"
-- "&c%victim%'s &efeet were made into bacon by a &6magma block"
+  - "&c%victim% &ewas removed by a hot &6&lmagma block... &ejust crouch?"
+  - "&c%victim%'s &efeet were made into bacon by a &6magma block"
 
 elytra-messages:
-- "&c%victim% &eflew into a wall and died...?"
-- "&c%victim% &egot slammed into a wall by his elytra"
+  - "&c%victim% &eflew into a wall and died...?"
+  - "&c%victim% &egot slammed into a wall by his elytra"
 
 wither-messages:
-- "&c%victim% &egot the wither disease"
-- "&c%victim% &ewithered away to the 4th dimension"
+  - "&c%victim% &egot the wither disease"
+  - "&c%victim% &ewithered away to the 4th dimension"
 
 suicide-messages:
-- "&c%victim% &ekilled themself"
-- "&c%victim% &ehad a mental breakdown and died"
+  - "&c%victim% &ekilled themself"
+  - "&c%victim% &ehad a mental breakdown and died"
 
 fire-messages:
-- "&c%victim% &estood in the fireplace"
-- "&c%victim% &eplayed with fire"
+  - "&c%victim% &estood in the fireplace"
+  - "&c%victim% &eplayed with fire"
 
 fire-tick-messages:
-- "&c%victim% &eforgot to stop, drop, and roll"
+  - "&c%victim% &eforgot to stop, drop, and roll"
 
 starvation-messages:
-- "&c%victim% &eforgot to eat"
-- "&c%victim%'s &emom said we have food at home"
+  - "&c%victim% &eforgot to eat"
+  - "&c%victim%'s &emom said we have food at home"
 
 cactus-messages:
-- "&c%victim% &ewas pricked to death"
-- "&c%victim% &etried acupuncture, but died"
-- "&c%victim% &e"
+  - "&c%victim% &ewas pricked to death"
+  - "&c%victim% &etried acupuncture, but died"
+  - "&c%victim% &e"
 
 potion-messages:
-- "&c%victim% &edied of black magic"
-- "&c%victim% &edied of coronavirus"
+  - "&c%victim% &edied of black magic"
+  - "&c%victim% &edied of coronavirus"
 
 void-messages:
-- "&c%victim% &ethought it would be fun to take a trip in the void"
+  - "&c%victim% &ethought it would be fun to take a trip in the void"
 
 lightning-messages:
-- "&c%victim% &ewas smitten by the gods"
-- "&c%victim% &ewas struck down by the gods"
+  - "&c%victim% &ewas smitten by the gods"
+  - "&c%victim% &ewas struck down by the gods"
 
 falling-block-messages:
-- "&c%victim% &ewas crushed by a falling block"
+  - "&c%victim% &ewas crushed by a falling block"
 
 freeze-messages:
-- "&c%victim% &efroze to death. &b&lBrrrrr!"
-- "&c%victim% &eforgot his winter jacket"
+  - "&c%victim% &efroze to death. &b&lBrrrrr!"
+  - "&c%victim% &eforgot his winter jacket"
 
 slime-messages:
-- "&c%victim% &ewas crushed by a &a&lGIANT SLIME"
-- "&c%victim% &ewas slimed to death while collecting slime balls"
+  - "&c%victim% &ewas crushed by a &a&lGIANT SLIME"
+  - "&c%victim% &ewas slimed to death while collecting slime balls"
 
 zombie-messages:
-- "&c%victim% &ewas eaten alive by a &a&lZombie"
-- "&c%victim% &ethought a &a&lZombie &ewas friendly"
+  - "&c%victim% &ewas eaten alive by a &a&lZombie"
+  - "&c%victim% &ethought a &a&lZombie &ewas friendly"
 
 pigman-messages:
-- "&c%victim% &eaggroed the &d&lPigmen &eand got eaten alive"
+  - "&c%victim% &eaggroed the &d&lPigmen &eand got eaten alive"
 
 skeleton-messages:
-- "&c%victim% &egot sniped by a bony &f&lSkeleton"
-- "&c%victim% &egot shot by a &f&lskeleton"
+  - "&c%victim% &egot sniped by a bony &f&lSkeleton"
+  - "&c%victim% &egot shot by a &f&lskeleton"
 
 magmacube-messages:
-- "&c%victim% &egot crushed by a &c&lGIANT MAGMA CUBE"
+  - "&c%victim% &egot crushed by a &c&lGIANT MAGMA CUBE"
 
 husk-messages:
-- "&c%victim% &egot eaten by a dessert dweller AKA a Husk"
+  - "&c%victim% &egot eaten by a dessert dweller AKA a Husk"
 
 spider-messages:
-- "&c%victim% &etried his luck against his worst fear... &c&lA SPIDER!"
+  - "&c%victim% &etried his luck against his worst fear... &c&lA SPIDER!"
 
 cavespider-messages:
-- "&c%victim% &egot bitten to death by a &c&lCave Spider"
+  - "&c%victim% &egot bitten to death by a &c&lCave Spider"
 
 witherskeleton-messages:
-- "&c%victim% &egot destroyed by a &f&lWither Skeleton &ewith a stone sword"
+  - "&c%victim% &egot destroyed by a &f&lWither Skeleton &ewith a stone sword"
 
 witherboss-messages:
-- "&c%victim% &egot his head blown off by the Wither"
-- "&c%victim% &egot a Wither skull to the face"
+  - "&c%victim% &egot his head blown off by the Wither"
+  - "&c%victim% &egot a Wither skull to the face"
 
 
 dragon-messages:
-- "&c%victim% &egot his guts ripped out by the &d&lEnder Dragon"
-- "&c%victim% &egot his head blown off by the &d&lEnder Dragon"
-- "&cc%victim% &efound a respawn screen, not the end portal"
+  - "&c%victim% &egot his guts ripped out by the &d&lEnder Dragon"
+  - "&c%victim% &egot his head blown off by the &d&lEnder Dragon"
+  - "&cc%victim% &efound a respawn screen, not the end portal"
 
 dragon-breath-messages:
-- "&c%victim% &etook a bath in the &d&lEnder Dragon's &ebreath"
-- "&c%victim% &etook a deep breath of the &d&lEnder Dragon's &e(nasty)"
+  - "&c%victim% &etook a bath in the &d&lEnder Dragon's &ebreath"
+  - "&c%victim% &etook a deep breath of the &d&lEnder Dragon's &e(nasty)"
 
 elderguardian-messages:
-- "&c%victim% &etried to clear a ocean monument but the &7&lElder Guardian &esaid no"
+  - "&c%victim% &etried to clear a ocean monument but the &7&lElder Guardian &esaid no"
 
 tnt-messages:
-- "&c%victim% &egot his head blown off by &c&lTNT"
-- "&c%victim% &egot blown up by &c&lTNT"
-- "&e&lBOOM! &c%victim% &efound out about explosives the hard way"
+  - "&c%victim% &egot his head blown off by &c&lTNT"
+  - "&c%victim% &egot blown up by &c&lTNT"
+  - "&e&lBOOM! &c%victim% &efound out about explosives the hard way"
 
 end-crystal-messages:
-- "&c%victim% &egot pieced by an &d&lEnd Crystal"
-- "&c%victim% &egot blown up by an &d&lEnd Crystal"
+  - "&c%victim% &egot pieced by an &d&lEnd Crystal"
+  - "&c%victim% &egot blown up by an &d&lEnd Crystal"
 
 creeper-messages:
-- "&c%victim% &egot blown up by a &a&lCreeper Ahhhh Man"
+  - "&c%victim% &egot blown up by a &a&lCreeper Ahhhh Man"
 
 ghast-messages:
-- "&c%victim% &egot fireballed by a &f&lGhast"
+  - "&c%victim% &egot fireballed by a &f&lGhast"
 
 enderman-messages:
-- "&c%victim% &elooked an &d&lEnderman &ein the eyes"
+  - "&c%victim% &elooked an &d&lEnderman &ein the eyes"
 
 silverfish-messages:
-- "&c%victim% &egot eaten by a &7&lSilverfish"
+  - "&c%victim% &egot eaten by a &7&lSilverfish"
 
 witch-messages:
-- "&c%victim% &edied to a &d&lWitch named Scarlett"
+  - "&c%victim% &edied to a &d&lWitch named Scarlett"
 
 shulker-messages:
-- "&c%victim% &edied trying to get some &d&lshulker &eshells"
-- "&c%victim% &egot shot by a &d&lShulker"
-- "&eLeviooosa! &c%victim% &egot ruined by a &d&lShulker"
+  - "&c%victim% &edied trying to get some &d&lshulker &eshells"
+  - "&c%victim% &egot shot by a &d&lShulker"
+  - "&eLeviooosa! &c%victim% &egot ruined by a &d&lShulker"
 
 guardian-messages:
-- "&c%victim% &egot killed by a &7&lGuardian... &esomehow?"
+  - "&c%victim% &egot killed by a &7&lGuardian... &esomehow?"
 
 golem-messages:
-- "&c%victim% &emade an &7&lIron Golem &emad"
+  - "&c%victim% &emade an &7&lIron Golem &emad"
 
 zombievillager-messages:
-- "&c%victim% &ewas made dinner of by a &a&lZombie Villager"
+  - "&c%victim% &ewas made dinner of by a &a&lZombie Villager"
 
 endermite-messages:
-- "&c%victim% &egot eaten by the &d&lEndermans &ehater, an &d&lEndermite"
+  - "&c%victim% &egot eaten by the &d&lEndermans &ehater, an &d&lEndermite"
 
 phantom-messages:
-- "&c%victim% &ewas kidnapped by a &3&lPhantom"
+  - "&c%victim% &ewas kidnapped by a &3&lPhantom"
 
 drowned-messages:
-- "&c%victim% &ewent for a late night swim and got eaten by a &b&lDrowned Zombie"
+  - "&c%victim% &ewent for a late night swim and got eaten by a &b&lDrowned Zombie"
 
 pillager-messages:
-- "&c%victim% &egot shot by a &7&lPillager"
+  - "&c%victim% &egot shot by a &7&lPillager"
 
 ravager-messages:
-- "&c%victim% &egot rammed by a &7&lRavager"
+  - "&c%victim% &egot rammed by a &7&lRavager"
 
 illusioner-messages:
-- "&c%victim% &ewas sent to the illusion world by an Illusioner"
-- "&c%victim% &ewas tricked by an &7&lIllusioner"
-- "&c%victim% &ewas killed by an &7&lIllusioner"
+  - "&c%victim% &ewas sent to the illusion world by an Illusioner"
+  - "&c%victim% &ewas tricked by an &7&lIllusioner"
+  - "&c%victim% &ewas killed by an &7&lIllusioner"
 
 bee-messages:
-- "&c%victim% &ewas stung by a &lBEE"
+  - "&c%victim% &ewas stung by a &lBEE"
 
 wolf-messages:
-- "&c%victim% &ewas ripped apart by a &f&lWolf"
-- "&c%victim% &eprovoked a &f&lWolf"
+  - "&c%victim% &ewas ripped apart by a &f&lWolf"
+  - "&c%victim% &eprovoked a &f&lWolf"
 
 llama-messages:
-- "&c%victim% &ewas spit to death by a Llama"
-- "&c%victim% &ecould not handle being spat on by a Llama"
+  - "&c%victim% &ewas spit to death by a Llama"
+  - "&c%victim% &ecould not handle being spat on by a Llama"
 
 blaze-messages:
-- "&c%victim% &ewas charred by a &6&lBlaze"
-- "&c%victim% &ewas turned into charcoal by a &6&lBlaze"
+  - "&c%victim% &ewas charred by a &6&lBlaze"
+  - "&c%victim% &ewas turned into charcoal by a &6&lBlaze"
 
 stray-messages:
-- "&c%victim% &ewas domed by a Stray"
+  - "&c%victim% &ewas domed by a Stray"
 
 vex-messages:
-- "&c%victim% &ewas eaten by a tiny flying (and annoying) &f&lVex"
-- "&c%victim% &egot vexed by a &f&lVex"
+  - "&c%victim% &ewas eaten by a tiny flying (and annoying) &f&lVex"
+  - "&c%victim% &egot vexed by a &f&lVex"
 
 vindicator-messages:
-- "&c%victim% &ewas hunted down by a &f&lVindicator"
-- "&c%victim% &efound Johnny... a &f&lVindicator?"
+  - "&c%victim% &ewas hunted down by a &f&lVindicator"
+  - "&c%victim% &efound Johnny... a &f&lVindicator?"
 
 evoker-messages:
-- "&c%victim% &ewas summoned to the dead by an &f&lEvoker"
-- "&c%victim% &etried the wrath of an &f&lEvoker"
-- "&c%victim% &ewas evoked by an &f&lEvoker"
+  - "&c%victim% &ewas summoned to the dead by an &f&lEvoker"
+  - "&c%victim% &etried the wrath of an &f&lEvoker"
+  - "&c%victim% &ewas evoked by an &f&lEvoker"
 
 pufferfish-messages:
-- "&c%victim% &edied to a Pufferfish..."
+  - "&c%victim% &edied to a Pufferfish..."
 
 polar-bear-messages:
-- "&c%victim% &ewas murdered by a nice Polar Bear... &ewhich means they hit it! (someone kill them)"
-- "&c%victim% &egot turned to snow by a &f&lPolar Bear"
+  - "&c%victim% &ewas murdered by a nice Polar Bear... &ewhich means they hit it! (someone kill them)"
+  - "&c%victim% &egot turned to snow by a &f&lPolar Bear"
 
 dolphin-messages:
-- "&c%victim% &eprovoked a Dolphin... and lost?"
-- "&c%victim% &ehit a Dolphin and they retaliated"
+  - "&c%victim% &eprovoked a Dolphin... and lost?"
+  - "&c%victim% &ehit a Dolphin and they retaliated"
 
 panda-messages:
-- "&c%victim% &ewas made into a Pandas dinner"
-- "&c%victim% &etried stealing a Pandas bamboo"
+  - "&c%victim% &ewas made into a Pandas dinner"
+  - "&c%victim% &etried stealing a Pandas bamboo"
 
 piglin-messages:
-- "&c%victim% &emet his maker against the new Piglins"
-- "&c%victim% &emade the Piglins mad. I mean, we warned you, don't steal from them..."
-- "&c%victim% &emisses Zombie Pigmen, so they took their anger out on a Piglin... and lost"
+  - "&c%victim% &emet his maker against the new Piglins"
+  - "&c%victim% &emade the Piglins mad. I mean, we warned you, don't steal from them..."
+  - "&c%victim% &emisses Zombie Pigmen, so they took their anger out on a Piglin... and lost"
 
 hoglin-messages:
-- "&c%victim% &ewas charged by a Hoglin, kind of rude?"
-- "&c%victim% &edidn't read the patch notes about Hoglins"
+  - "&c%victim% &ewas charged by a Hoglin, kind of rude?"
+  - "&c%victim% &edidn't read the patch notes about Hoglins"
 
 zoglin-messages:
-- "&c%victim% &eate a Zoglins horn for dinner"
-- "&c%victim% &ewas rammed by a Zoglin"
--
+  - "&c%victim% &eate a Zoglins horn for dinner"
+  - "&c%victim% &ewas rammed by a Zoglin"
+
 goat-messages:
-- "&c%victim% &ewas headbutted by a Goat"
-- "&c%victim% &ewas impaled by a Goat horn"
+  - "&c%victim% &ewas headbutted by a Goat"
+  - "&c%victim% &ewas impaled by a Goat horn"
 
 zombified-piglin-messages:
-- "&c%victim% &etook a Piglin to the overworld and was murdered by their new, not so friendly pet"
-- "&c%victim% &edied to a Piglin... I mean, Pigman... I mean, Zombified Piglin"
+  - "&c%victim% &etook a Piglin to the overworld and was murdered by their new, not so friendly pet"
+  - "&c%victim% &edied to a Piglin... I mean, Pigman... I mean, Zombified Piglin"
 
 fox-messages:
-- "&c%victim% &efoxed around and found out"
-- "&c%victim% &ewas chewed up by a Fox"
+  - "&c%victim% &efoxed around and found out"
+  - "&c%victim% &ewas chewed up by a Fox"
 
 warden-messages:
-- "&c%victim% &ewas killed by a Warden... I mean, what did you expect?"
-- "&c%victim% &egot sonic boomed by a Warden"
-- "&eA Warden protected the Deep Dark from &c%victim%"
+  - "&c%victim% &ewas killed by a Warden... I mean, what did you expect?"
+  - "&eA Warden protected the Deep Dark from &c%victim%"
+
+warden-sonic-boom-messages:
+  - "&c%victim% &ewas sonic boomed by a Warden"
+  - "&c%victim% &egot his ears blown out by a Warden's sonic boom"
 
 # This is for any messages that haven't been added, so if you die to a cause which doesn't have any messages,
 # one of these messages will display instead. (Please report any missing messages in my spigot discussion)
 unknown-messages:
-- "&c%victim% &edied to unknown causes"
-- "&c%victim% &edied"
-- "&c%victim% &ewas killed"
+  - "&c%victim% &edied to unknown causes"
+  - "&c%victim% &edied"
+  - "&c%victim% &ewas killed"
 
 fireball-messages:
-- "&c%victim% &ewas fireballed until they burnt to death"
+  - "&c%victim% &ewas fireballed until they burnt to death"
 
 arrow-messages:
-- "&c%victim% &elooked like a porcupine after getting shot to death"
+  - "&c%victim% &elooked like a porcupine after getting shot to death"
 
 # Only here to help me debug my plugin, not suggested you enable.
 developer-mode: false
+
+# Config version, do not change this.
+config-version: 2
  ```

--- a/README.md
+++ b/README.md
@@ -107,7 +107,7 @@ enable-custom-name-entity-messages: true
 custom-name-entity-messages:
   - "&c%victim% &egot rocked by %entity-name%"
   - "&c%victim% &ewas put to sleep by %entity-name%"
-  - "%entity-name% &eate &c%victim%'s &esoul"
+  - "&c%entity-name% &eate &c%victim%'s &esoul"
   - "&c%victim% &ewishes they didn't fight %entity-name%"
 
 # Placeholders for ALL below messages: %victim%, %victim-nick%, %entity-name%, %victim-x%, %victim-y%, %victim-z%

--- a/README.md
+++ b/README.md
@@ -185,6 +185,11 @@ freeze-messages:
   - "&c%victim% &efroze to death. &b&lBrrrrr!"
   - "&c%victim% &eforgot his winter jacket"
 
+firework-messages:
+  - "&c%victim% &elit the fuse on a firework too soon"
+  - "&c%victim% &ewent out with a bang"
+  - "&c%victim% &eblasted off into space"
+
 slime-messages:
   - "&c%victim% &ewas crushed by a &a&lGIANT SLIME"
   - "&c%victim% &ewas slimed to death while collecting slime balls"

--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,10 @@
                             <pattern>org.bstats</pattern>
                             <shadedPattern>org.spartandevs.customdeathmessages</shadedPattern>
                         </relocation>
+                        <relocation>
+                            <pattern>dev.dejvokep.boostedyaml</pattern>
+                            <shadedPattern>org.spartandevs.util</shadedPattern>
+                        </relocation>
                     </relocations>
                 </configuration>
             </plugin>
@@ -129,6 +133,11 @@
             <groupId>io.github.bananapuncher714</groupId>
             <artifactId>nbteditor</artifactId>
             <version>7.18.5</version>
+        </dependency>
+        <dependency>
+            <groupId>dev.dejvokep</groupId>
+            <artifactId>boosted-yaml</artifactId>
+            <version>1.3</version>
         </dependency>
     </dependencies>
 </project>

--- a/src/main/java/org/spartandevs/customdeathmessages/CustomDeathMessages.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/CustomDeathMessages.java
@@ -36,11 +36,6 @@ public final class CustomDeathMessages extends JavaPlugin {
         registerCommands();
     }
 
-    @Override
-    public void onDisable() {
-        configManager.reloadConfig();
-    }
-
     private void registerEvents() {
         getServer().getPluginManager().registerEvents(new BukkitLoginListener(this), this);
         getServer().getPluginManager().registerEvents(new BukkitPlayerDeathListener(this), this);

--- a/src/main/java/org/spartandevs/customdeathmessages/CustomDeathMessages.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/CustomDeathMessages.java
@@ -36,6 +36,11 @@ public final class CustomDeathMessages extends JavaPlugin {
         registerCommands();
     }
 
+    @Override
+    public void onDisable() {
+        configManager.reloadConfig();
+    }
+
     private void registerEvents() {
         getServer().getPluginManager().registerEvents(new BukkitLoginListener(this), this);
         getServer().getPluginManager().registerEvents(new BukkitPlayerDeathListener(this), this);
@@ -43,6 +48,7 @@ public final class CustomDeathMessages extends JavaPlugin {
         getServer().getPluginManager().registerEvents(new CustomPlayerDeathListener(this), this);
     }
 
+    @SuppressWarnings("deprecation") // Unstable API
     private void registerCommands() {
         BukkitCommandManager commandManager = new BukkitCommandManager(this);
         commandManager.enableUnstableAPI("help");
@@ -124,10 +130,10 @@ public final class CustomDeathMessages extends JavaPlugin {
         return cooldownManager;
     }
 
-    public void reload() {
-        configManager.reloadConfig();
+    public boolean reload() {
         messagePropagator.clear();
         cooldownManager.clearCooldowns();
+        return configManager.reloadConfig();
     }
 
     public MessagePropagator getMessagePropagator() {

--- a/src/main/java/org/spartandevs/customdeathmessages/commands/CDMCommand.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/commands/CDMCommand.java
@@ -61,7 +61,7 @@ public class CDMCommand extends CDMBaseCommand {
             builder.append(ChatColor.capitalize(o.toString().toLowerCase().replace("_", " ")));
             builder.append(", ");
         }
-        
+
         builder.delete(builder.length() - 2, builder.length());
         return builder.toString();
     }
@@ -83,7 +83,7 @@ public class CDMCommand extends CDMBaseCommand {
     @CommandCompletion("@boolConfigPaths true|false")
     public void onSetBoolean(CommandSender sender, @Conditions("validBoolConfigPath") String configPath, boolean value) {
         plugin.getConfigManager().setBoolean(configPath, value);
-        sendMessage(sender, "&aSet config value. You may need to reload the plugin for this to take effect.");
+        sendMessage(sender, "&aSet config value.");
     }
 
     @Subcommand("set message")
@@ -93,7 +93,7 @@ public class CDMCommand extends CDMBaseCommand {
     @CommandCompletion("@stringConfigPaths @nothing")
     public void onSetString(CommandSender sender, @Conditions("validStringConfigPath") String configPath, String value) {
         plugin.getConfigManager().setString(configPath, value);
-        sendMessage(sender, "&aSet config value. You may need to reload the plugin for this to take effect.");
+        sendMessage(sender, "&aSet config value.");
     }
 
     @Subcommand("set number")
@@ -103,7 +103,7 @@ public class CDMCommand extends CDMBaseCommand {
     @CommandCompletion("@numConfigPaths @nothing")
     public void onSetNumber(CommandSender sender, @Conditions("validNumConfigPath") String configPath, double value) {
         plugin.getConfigManager().setDouble(configPath, value);
-        sendMessage(sender, "&aSet config value. You may need to reload the plugin for this to take effect.");
+        sendMessage(sender, "&aSet config value.");
     }
 
     @Subcommand("debug shoot")

--- a/src/main/java/org/spartandevs/customdeathmessages/commands/CDMCommand.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/commands/CDMCommand.java
@@ -17,12 +17,15 @@ public class CDMCommand extends CDMBaseCommand {
         help.showHelp();
     }
 
-    @Subcommand("reload")
+    @Subcommand("reload|rl")
     @CommandPermission("cdm.reload")
     @Description("Reloads the config file and other resources.")
     public void onReload(CommandSender sender) {
-        plugin.reload();
-        sendMessage(sender, "&aConfig reloaded.");
+        if (plugin.reload()) {
+            sendMessage(sender, "&aPlugin reloaded.");
+        } else {
+            sendMessage(sender, "&cFailed to reload plugin.");
+        }
     }
 
     @Subcommand("add")
@@ -58,6 +61,7 @@ public class CDMCommand extends CDMBaseCommand {
             builder.append(ChatColor.capitalize(o.toString().toLowerCase().replace("_", " ")));
             builder.append(", ");
         }
+        
         builder.delete(builder.length() - 2, builder.length());
         return builder.toString();
     }

--- a/src/main/java/org/spartandevs/customdeathmessages/commands/CDMCommand.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/commands/CDMCommand.java
@@ -121,6 +121,23 @@ public class CDMCommand extends CDMBaseCommand {
         sendMessage(sender, "&aShot " + target.getName() + " with an instant-kill arrow.");
     }
 
+    @Subcommand("debug prime")
+    @Syntax("<player>")
+    @CommandCompletion("@players")
+    @CommandPermission("cdm.debug")
+    @Description("Sets the player's health to 1. Used for debugging.")
+    @Conditions("debugEnabled")
+    public void onDebugPrime(Player sender, @Optional Player target) {
+        if (target == null) {
+            target = sender;
+        }
+
+        target.setHealth(1);
+        target.setSaturation(0);
+        target.setFoodLevel(14);
+        sendMessage(sender, "&aPrimed " + target.getName() + ".");
+    }
+
     @CatchUnknown
     public void onUnknown(CommandSender sender) {
         sendMessage(sender, "&cUnknown command. Type /cdm help for help.");

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
@@ -61,7 +61,8 @@ public class BukkitKilledByEntityListener implements Listener {
             deathCause = DeathCause.WITHER_BOSS;
         }
 
-        if (entity.getCustomName() != null) {
+        // Avoid ❤ in custom named entities (McMMO)
+        if (entity.getCustomName() != null && !entity.getCustomName().contains("❤")) {
             deathCause = DeathCause.CUSTOM_NAMED_ENTITY;
         }
 

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
@@ -35,7 +35,9 @@ public class BukkitKilledByEntityListener implements Listener {
             Projectile proj = (Projectile) entity;
 
             if (proj.getShooter() != null) {
-                entity = (Entity) proj.getShooter();
+                if (proj.getShooter() instanceof Entity) {
+                    entity = (Entity) proj.getShooter();
+                }
 
                 if (entity instanceof Player) {
                     deathCause = DeathCause.PLAYER;
@@ -51,6 +53,10 @@ public class BukkitKilledByEntityListener implements Listener {
                     deathCause = DeathCause.PILLAGER;
                 } else if (entity instanceof Drowned) {
                     deathCause = DeathCause.DROWNED;
+                }
+
+                if (proj instanceof Firework) {
+                    deathCause = DeathCause.FIREWORK;
                 }
             }
         }

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
@@ -48,9 +48,10 @@ public class BukkitKilledByEntityListener implements Listener {
             deathCause = DeathCause.WITHER_BOSS;
         }
 
-        // Avoid ❤ in custom named entities (McMMO)♥
+        // Avoid ❤ in custom named entities (McMMO)
         if (entity.getCustomName() != null && !entity.getCustomName().contains("❤")
-                && !entity.getCustomName().contains("♥") && !entity.getCustomName().contains("♡")) {
+                && !entity.getCustomName().contains("♥") && !entity.getCustomName().contains("♡")
+                && plugin.getConfigManager().isCustomNamedEntityMessageEnabled()) {
             deathCause = DeathCause.CUSTOM_NAMED_ENTITY;
         }
 

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
@@ -61,8 +61,9 @@ public class BukkitKilledByEntityListener implements Listener {
             deathCause = DeathCause.WITHER_BOSS;
         }
 
-        // Avoid ❤ in custom named entities (McMMO)
-        if (entity.getCustomName() != null && !entity.getCustomName().contains("❤")) {
+        // Avoid ❤ in custom named entities (McMMO)♥
+        if (entity.getCustomName() != null && !entity.getCustomName().contains("❤")
+                && !entity.getCustomName().contains("♥") && !entity.getCustomName().contains("♡")) {
             deathCause = DeathCause.CUSTOM_NAMED_ENTITY;
         }
 

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitKilledByEntityListener.java
@@ -1,6 +1,8 @@
 package org.spartandevs.customdeathmessages.listeners;
 
-import org.bukkit.entity.*;
+import org.bukkit.entity.Entity;
+import org.bukkit.entity.Player;
+import org.bukkit.entity.Projectile;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
 import org.bukkit.event.Listener;
@@ -29,37 +31,16 @@ public class BukkitKilledByEntityListener implements Listener {
         }
 
         Entity entity = event.getDamager();
-        DeathCause deathCause = DeathCause.fromEntityType(entity.getType(), plugin);
 
         if (entity instanceof Projectile) {
             Projectile proj = (Projectile) entity;
 
-            if (proj.getShooter() != null) {
-                if (proj.getShooter() instanceof Entity) {
-                    entity = (Entity) proj.getShooter();
-                }
-
-                if (entity instanceof Player) {
-                    deathCause = DeathCause.PLAYER;
-                } else if (entity instanceof Skeleton) {
-                    deathCause = DeathCause.SKELETON;
-                } else if (entity instanceof Husk) {
-                    deathCause = DeathCause.HUSK;
-                } else if (entity instanceof Stray) {
-                    deathCause = DeathCause.STRAY;
-                } else if (entity instanceof WitherSkeleton) {
-                    deathCause = DeathCause.WITHER_SKELETON;
-                } else if (entity instanceof Pillager) {
-                    deathCause = DeathCause.PILLAGER;
-                } else if (entity instanceof Drowned) {
-                    deathCause = DeathCause.DROWNED;
-                }
-
-                if (proj instanceof Firework) {
-                    deathCause = DeathCause.FIREWORK;
-                }
+            if (proj.getShooter() != null && proj.getShooter() instanceof Entity) {
+                entity = (Entity) proj.getShooter();
             }
         }
+
+        DeathCause deathCause = DeathCause.from(entity.getType(), plugin);
 
         // WITHER is used as an effect and entity damage cause, so we need to differentiate
         // here, WITHER is the boss, so we use WITHER_BOSS

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitPlayerDeathListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitPlayerDeathListener.java
@@ -42,7 +42,7 @@ public class BukkitPlayerDeathListener implements Listener {
             killer = propagated.getKiller();
         }
 
-        if (propagated != null && (deathCause == DeathCause.UNKNOWN || deathCause == DeathCause.ENTITY_ATTACK)) {
+        if (propagated != null && (deathCause == DeathCause.UNKNOWN || deathCause == DeathCause.ENTITY_ATTACK || deathCause == DeathCause.ENTITY_EXPLOSION)) {
             deathCause = propagated.getDeathCause();
         }
 

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitPlayerDeathListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/BukkitPlayerDeathListener.java
@@ -35,15 +35,15 @@ public class BukkitPlayerDeathListener implements Listener {
             return;
         }
 
-        DeathCause deathCause = DeathCause.fromDamageCause(victim.getLastDamageCause().getCause(), plugin);
+        DeathCause deathCause = DeathCause.from(victim.getLastDamageCause().getCause(), plugin);
         MessageInfo propagated = plugin.getMessagePropagator().getDeathMessage(victim.getUniqueId());
 
-        if (propagated != null && killer == null) {
-            killer = propagated.getKiller();
-        }
-
-        if (propagated != null && (deathCause == DeathCause.UNKNOWN || deathCause == DeathCause.ENTITY_ATTACK || deathCause == DeathCause.ENTITY_EXPLOSION)) {
+        if (propagated != null) {
             deathCause = propagated.getDeathCause();
+
+            if (killer == null) {
+                killer = propagated.getKiller();
+            }
         }
 
         deathMessageSetter = event::setDeathMessage;

--- a/src/main/java/org/spartandevs/customdeathmessages/listeners/CustomPlayerDeathListener.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/listeners/CustomPlayerDeathListener.java
@@ -68,7 +68,11 @@ public class CustomPlayerDeathListener implements Listener {
 
         if (config.isGlobalMessageEnabled()) {
             if (event.getDeathCause() == DeathCause.UNKNOWN) {
-                plugin.getLogger().warning("Unknown death cause for killer " + event.getKiller().getType());
+                if (event.getKiller() != null) {
+                    plugin.getLogger().warning("Unknown death cause for killer " + event.getKiller().getType());
+                } else {
+                    plugin.getLogger().warning("Unknown death cause with no killer");
+                }
             }
 
             DeathMessageResolver resolver = weapon != null && weapon.getType() == Material.AIR

--- a/src/main/java/org/spartandevs/customdeathmessages/util/ConfigManager.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/util/ConfigManager.java
@@ -142,6 +142,10 @@ public class ConfigManager {
         return config.getDouble("message-cooldown");
     }
 
+    public boolean isCustomNamedEntityMessageEnabled() {
+        return config.getBoolean("enable-custom-name-entity-messages");
+    }
+
     public boolean isDebugEnabled() {
         return config.getBoolean("developer-mode");
     }

--- a/src/main/java/org/spartandevs/customdeathmessages/util/ConfigManager.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/util/ConfigManager.java
@@ -151,12 +151,12 @@ public class ConfigManager {
         metrics.addCustomChart(new SimplePie("head_drop_percentage", () -> String.valueOf(config.getDouble("drop-head-chance"))));
         metrics.addCustomChart(new SimplePie("give_killer_speed", () -> getBooleanString(config.getBoolean("give-killer-speed")))); // legacy
         metrics.addCustomChart(new SimplePie("heart_sucker", () -> getBooleanString(config.getBoolean("heart-sucker")))); // legacy
-        metrics.addCustomChart(new SimplePie("do_lightning", () -> getBooleanString(config.getBoolean("do-lightning"))));
+        metrics.addCustomChart(new SimplePie("enable_lightning", () -> getBooleanString(config.getBoolean("enable-lightning"))));
         metrics.addCustomChart(new SimplePie("enable_global_messages", () -> getBooleanString(config.getBoolean("enable-global-messages"))));
         metrics.addCustomChart(new SimplePie("enable_pvp_messages", () -> getBooleanString(config.getBoolean("enable-pvp-messages"))));
         metrics.addCustomChart(new SimplePie("enable_entity_name_messages", () -> getBooleanString(config.getBoolean("enable-entity-name-messages"))));
-        metrics.addCustomChart(new SimplePie("enable_original_hover_message", () -> getBooleanString(config.getBoolean("original-hover-message"))));
-        metrics.addCustomChart(new SimplePie("enable_item_tooltip_message", () -> getBooleanString(config.getBoolean("enable-item-hover"))));
+        metrics.addCustomChart(new SimplePie("enable_original_hover_message", () -> getBooleanString(config.getBoolean("enable-original-on-hover"))));
+        metrics.addCustomChart(new SimplePie("enable_item_tooltip_message", () -> getBooleanString(config.getBoolean("enable-item-on-hover"))));
     }
 
     private static String getBooleanString(boolean value) {

--- a/src/main/java/org/spartandevs/customdeathmessages/util/ConfigManager.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/util/ConfigManager.java
@@ -1,66 +1,84 @@
 package org.spartandevs.customdeathmessages.util;
 
+import dev.dejvokep.boostedyaml.YamlDocument;
+import dev.dejvokep.boostedyaml.dvs.versioning.BasicVersioning;
+import dev.dejvokep.boostedyaml.settings.dumper.DumperSettings;
+import dev.dejvokep.boostedyaml.settings.general.GeneralSettings;
+import dev.dejvokep.boostedyaml.settings.loader.LoaderSettings;
+import dev.dejvokep.boostedyaml.settings.updater.UpdaterSettings;
 import org.bstats.bukkit.Metrics;
 import org.bstats.charts.SimplePie;
 import org.spartandevs.customdeathmessages.CustomDeathMessages;
 
+import java.io.File;
+import java.io.IOException;
+import java.io.InputStream;
 import java.text.MessageFormat;
-import java.util.*;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Random;
+import java.util.Set;
 
 public class ConfigManager {
     private final CustomDeathMessages plugin;
+    private final YamlDocument config;
     private Set<String> keys;
-    private final Map<DeathCause, List<String>> messages = new HashMap<>();
-    private boolean checkUpdatesEnabled;
-    private boolean globalMessagesEnabled;
-    private boolean doLightningStrike;
-    private double dropHeadChance;
-    private String headName;
-    private boolean doPvpMessages;
-    private String killerMessage;
-    private String victimMessage;
-    private List<String> meleeMessages;
-    private boolean originalOnHoverEnabled;
-    private boolean itemOnHoverEnabled;
-    private boolean debugEnabled;
-    private double killMessageCooldown;
 
     public ConfigManager(CustomDeathMessages plugin) {
         this.plugin = plugin;
+        this.config = getConfig();
     }
 
     public void loadConfig() {
-        plugin.saveDefaultConfig();
         registerStatistics();
 
         keys = plugin.getConfig().getValues(true).keySet();
 
-        for (DeathCause cause : DeathCause.values()) {
-            messages.put(cause, plugin.getConfig().getStringList(cause.getPath()));
+        if (config.getDouble("drop-head-percentage") > 1) {
+            plugin.getLogger().warning("Config misconfiguration: drop-head-chance should be a decimal between 0 and 1");
         }
-
-        checkUpdatesEnabled = plugin.getConfig().getBoolean("enable-update-messages");
-        globalMessagesEnabled = plugin.getConfig().getBoolean("enable-global-messages");
-        doLightningStrike = plugin.getConfig().getBoolean("do-lightning");
-        dropHeadChance = plugin.getConfig().getDouble("drop-head-chance");
-        headName = plugin.getConfig().getString("head-name");
-        doPvpMessages = plugin.getConfig().getBoolean("enable-pvp-messages");
-        killerMessage = plugin.getConfig().getString("killer-message");
-        victimMessage = plugin.getConfig().getString("victim-message");
-        meleeMessages = plugin.getConfig().getStringList("melee-death-messages");
-        originalOnHoverEnabled = plugin.getConfig().getBoolean("original-hover-message");
-        itemOnHoverEnabled = plugin.getConfig().getBoolean("enable-item-hover");
-        killMessageCooldown = plugin.getConfig().getDouble("kill-message-cooldown");
-        debugEnabled = plugin.getConfig().getBoolean("developer-mode");
     }
 
-    public void reloadConfig() {
-        plugin.reloadConfig();
-        loadConfig();
+    private YamlDocument getConfig() {
+        InputStream resource = plugin.getResource("config.yml");
+
+        if (resource == null) {
+            warnAndDisable();
+            return null;
+        }
+
+        try {
+            return YamlDocument.create(
+                    new File(plugin.getDataFolder(), "config.yml"),
+                    resource,
+                    GeneralSettings.DEFAULT,
+                    LoaderSettings.builder().setAutoUpdate(true).build(),
+                    DumperSettings.DEFAULT,
+                    UpdaterSettings.builder().setVersioning(new BasicVersioning("config-version")).build());
+        } catch (IOException e) {
+            warnAndDisable();
+            return null;
+        }
+    }
+
+    public boolean reloadConfig() {
+        try {
+            config.save();
+            config.reload();
+            return true;
+        } catch (IOException e) {
+            plugin.getLogger().warning("Unable to reload config.yml, changes will not take effect.");
+            return false;
+        }
+    }
+
+    private void warnAndDisable() {
+        plugin.getLogger().warning("Unable to load config.yml from jar, disabling plugin.");
+        plugin.getServer().getPluginManager().disablePlugin(plugin);
     }
 
     public String getMessage(DeathCause cause) {
-        List<String> messages = this.messages.get(cause);
+        List<String> messages = config.getStringList(cause.getPath());
 
         if (invalidCollection(messages, cause.getPath())) {
             return null;
@@ -70,38 +88,40 @@ public class ConfigManager {
     }
 
     public boolean doLightningStrike() {
-        return doLightningStrike;
+        return config.getBoolean("do-lightning");
     }
 
     public boolean dropHead() {
-        return new Random().nextDouble() <= dropHeadChance;
+        return new Random().nextDouble() <= config.getDouble("drop-head-chance");
     }
 
     public String getHeadName() {
-        return headName;
+        return config.getString("head-name");
     }
 
     public boolean doPvpMessages() {
-        return doPvpMessages;
+        return config.getBoolean("enable-pvp-messages");
     }
 
     public String getKillerMessage() {
-        return killerMessage;
+        return config.getString("killer-message");
     }
 
     public String getVictimMessage() {
-        return victimMessage;
+        return config.getString("victim-message");
     }
 
     public boolean isCheckUpdatesEnabled() {
-        return checkUpdatesEnabled;
+        return config.getBoolean("enable-update-messages");
     }
 
     public boolean isGlobalMessageEnabled() {
-        return globalMessagesEnabled;
+        return config.getBoolean("enable-global-messages");
     }
 
     public String getMeleeMessage() {
+        List<String> meleeMessages = config.getStringList("melee-death-messages");
+
         if (invalidCollection(meleeMessages, "melee-death-messages")) {
             return null;
         }
@@ -110,32 +130,32 @@ public class ConfigManager {
     }
 
     public boolean isOriginalOnHoverEnabled() {
-        return originalOnHoverEnabled;
+        return config.getBoolean("original-hover-message");
     }
 
     public boolean isItemOnHoverEnabled() {
-        return itemOnHoverEnabled;
+        return config.getBoolean("enable-item-hover");
     }
 
     public double getCooldown() {
-        return killMessageCooldown;
+        return config.getDouble("message-cooldown");
     }
 
     public boolean isDebugEnabled() {
-        return debugEnabled;
+        return config.getBoolean("developer-mode");
     }
 
     private void registerStatistics() {
         Metrics metrics = new Metrics(plugin, 7287);
-        metrics.addCustomChart(new SimplePie("head_drop_percentage", () -> String.valueOf(dropHeadChance)));
-        metrics.addCustomChart(new SimplePie("give_killer_speed", () -> getBooleanString(plugin.getConfig().getBoolean("give-killer-speed")))); // legacy
-        metrics.addCustomChart(new SimplePie("heart_sucker", () -> getBooleanString(plugin.getConfig().getBoolean("heart-sucker")))); // legacy
-        metrics.addCustomChart(new SimplePie("do_lightning", () -> getBooleanString(doLightningStrike)));
-        metrics.addCustomChart(new SimplePie("enable_global_messages", () -> getBooleanString(globalMessagesEnabled)));
-        metrics.addCustomChart(new SimplePie("enable_pvp_messages", () -> getBooleanString(doPvpMessages)));
-        metrics.addCustomChart(new SimplePie("enable_entity_name_messages", () -> getBooleanString(plugin.getConfig().getBoolean("enable-entity-name-messages"))));
-        metrics.addCustomChart(new SimplePie("enable_original_hover_message", () -> getBooleanString(originalOnHoverEnabled)));
-        metrics.addCustomChart(new SimplePie("enable_item_tooltip_message", () -> getBooleanString(itemOnHoverEnabled)));
+        metrics.addCustomChart(new SimplePie("head_drop_percentage", () -> String.valueOf(config.getDouble("drop-head-chance"))));
+        metrics.addCustomChart(new SimplePie("give_killer_speed", () -> getBooleanString(config.getBoolean("give-killer-speed")))); // legacy
+        metrics.addCustomChart(new SimplePie("heart_sucker", () -> getBooleanString(config.getBoolean("heart-sucker")))); // legacy
+        metrics.addCustomChart(new SimplePie("do_lightning", () -> getBooleanString(config.getBoolean("do-lightning"))));
+        metrics.addCustomChart(new SimplePie("enable_global_messages", () -> getBooleanString(config.getBoolean("enable-global-messages"))));
+        metrics.addCustomChart(new SimplePie("enable_pvp_messages", () -> getBooleanString(config.getBoolean("enable-pvp-messages"))));
+        metrics.addCustomChart(new SimplePie("enable_entity_name_messages", () -> getBooleanString(config.getBoolean("enable-entity-name-messages"))));
+        metrics.addCustomChart(new SimplePie("enable_original_hover_message", () -> getBooleanString(config.getBoolean("original-hover-message"))));
+        metrics.addCustomChart(new SimplePie("enable_item_tooltip_message", () -> getBooleanString(config.getBoolean("enable-item-hover"))));
     }
 
     private static String getBooleanString(boolean value) {
@@ -143,57 +163,43 @@ public class ConfigManager {
     }
 
     public void addCustomMessage(DeathCause cause, String message) {
-        Set<DeathCause> causes = DeathCause.deathCauseWithPath(cause);
+        List<String> configMessages = config.getStringList(cause.getPath());
+        configMessages.add(message);
+        config.set(cause.getPath(), configMessages);
 
-        for (DeathCause deathCause : causes) {
-            List<String> configMessages = messages.get(deathCause);
-            configMessages.add(message);
-            plugin.getConfig().set(deathCause.getPath(), configMessages);
-        }
-
-        plugin.saveConfig();
     }
 
     public void removeCustomMessage(DeathCause cause, int index) {
-        Set<DeathCause> causes = DeathCause.deathCauseWithPath(cause);
-
-        for (DeathCause deathCause : causes) {
-            List<String> configMessages = messages.get(deathCause);
-            configMessages.remove(index);
-            plugin.getConfig().set(deathCause.getPath(), configMessages);
-        }
-
-        plugin.saveConfig();
+        List<String> configMessages = config.getStringList(cause.getPath());
+        configMessages.remove(index);
+        config.set(cause.getPath(), configMessages);
     }
 
     public List<String> listDeathMessages(DeathCause cause) {
-        return messages.get(cause);
+        return config.getStringList(cause.getPath());
     }
 
     public void setBoolean(String path, boolean value) {
-        plugin.getConfig().set(path, value);
-        plugin.saveConfig();
+        config.set(path, value);
     }
 
     public void setDouble(String path, double value) {
-        plugin.getConfig().set(path, value);
-        plugin.saveConfig();
+        config.set(path, value);
     }
 
     public void setString(String path, String value) {
-        plugin.getConfig().set(path, value);
-        plugin.saveConfig();
+        config.set(path, value);
     }
 
     public int getMessagesCount(DeathCause cause) {
-        return messages.get(cause).size();
+        return config.getStringList(cause.getPath()).size();
     }
 
     public Set<String> getStringConfigPaths() {
         Set<String> paths = new HashSet<>();
 
         for (String path : keys) {
-            if (plugin.getConfig().get(path) instanceof String) {
+            if (config.get(path) instanceof String) {
                 paths.add(path);
             }
         }
@@ -205,7 +211,7 @@ public class ConfigManager {
         Set<String> paths = new HashSet<>();
 
         for (String path : keys) {
-            if (plugin.getConfig().get(path) instanceof Boolean) {
+            if (config.get(path) instanceof Boolean) {
                 paths.add(path);
             }
         }
@@ -217,7 +223,7 @@ public class ConfigManager {
         Set<String> paths = new HashSet<>();
 
         for (String path : keys) {
-            if (plugin.getConfig().get(path) instanceof Double || plugin.getConfig().get(path) instanceof Integer) {
+            if (config.get(path) instanceof Double || config.get(path) instanceof Integer) {
                 paths.add(path);
             }
         }

--- a/src/main/java/org/spartandevs/customdeathmessages/util/DeathCause.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/util/DeathCause.java
@@ -1,7 +1,5 @@
 package org.spartandevs.customdeathmessages.util;
 
-import org.bukkit.entity.EntityType;
-import org.bukkit.event.entity.EntityDamageEvent;
 import org.spartandevs.customdeathmessages.CustomDeathMessages;
 
 import java.util.Arrays;
@@ -14,6 +12,7 @@ public enum DeathCause {
     CUSTOM("unknown-messages"),
     ENTITY_ATTACK("unknown-messages"),
     CUSTOM_NAMED_ENTITY("custom-name-entity-messages"),
+    PROJECTILE("arrow-messages"),
     PLAYER("global-pvp-death-messages"),
     BLOCK("falling-block-messages"),
     VOID("void-messages"),
@@ -116,26 +115,14 @@ public enum DeathCause {
         return path;
     }
 
-
-    public static DeathCause fromDamageCause(EntityDamageEvent.DamageCause cause, CustomDeathMessages plugin) {
+    public static <E extends Enum<E>> DeathCause from(Enum<E> namedEnum, CustomDeathMessages plugin) {
         for (DeathCause deathCause : values()) {
-            if (deathCause.name().equalsIgnoreCase(cause.name())) {
+            if (deathCause.name().equalsIgnoreCase(namedEnum.name())) {
                 return deathCause;
             }
         }
 
-        plugin.getLogger().warning("Unknown damage cause '" + cause.name() + "'. If you would like this message to be added, please leave a message on the plugin discussion.");
-        return DeathCause.UNKNOWN;
-    }
-
-    public static DeathCause fromEntityType(EntityType entity, CustomDeathMessages plugin) {
-        for (DeathCause deathCause : values()) {
-            if (deathCause.name().equalsIgnoreCase(entity.name())) {
-                return deathCause;
-            }
-        }
-
-        plugin.getLogger().warning("Unknown entity '" + entity.name() + "'. If you would like this message to be added, please leave a message on the plugin discussion.");
+        plugin.getLogger().warning("Unknown entity or damage cause '" + namedEnum.name() + "'. If you would like this message to be added, please leave a message on the plugin discussion.");
         return DeathCause.UNKNOWN;
     }
 

--- a/src/main/java/org/spartandevs/customdeathmessages/util/Version.java
+++ b/src/main/java/org/spartandevs/customdeathmessages/util/Version.java
@@ -21,7 +21,6 @@ public enum Version {
 
     private static Version getServerVersion() {
         String version = org.bukkit.Bukkit.getServer().getClass().getPackage().getName().split("\\.")[3];
-        System.out.println("Server version: " + version);
 
         switch (version) {
             case "v1_8_R1":

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -1,36 +1,34 @@
-# Enable Update Messages: Toggles update messages on or off.
+# Enable Update Messages: enables update messages
 enable-update-messages: true
 
 # To use hex colors: &#hex
-# PvP Messages only for when a player is killed by another player, enabled by default
+# PvP Messages: sends a message to the killer and victim when a player is killed by another player.
 # Placeholders for pvp messages: %victim%, %victim-nick%, %killer%, %killer-nick%, %killer-x%, %killer-y%, %killer-z%, %victim-x%, %victim-y%, %victim-z%
 enable-pvp-messages: true
 killer-message: '&e[&cDeathMessages&e] &eYou killed &c%victim%'
 victim-message: '&e[&cDeathMessages&e] &eYou were killed by &c%killer%'
 
-# Toggleable features: set true to enable, false to disable. All features except lightning-effect are false by default.
-# Drop Head Percentage: self-explanatory, chance of a player head to drop
-# Do Lightning: creates a lightning effect that will not harm or damage anything when the victim is killed. True by default.
-# Head Name: Sets the name of a head whenever dropped from a player.
-head-name: "&c%victim%'s Head"
-do-lightning: true
+# Lightning: lightning strike effect at the location of the death.
+enable-lightning: true
 
-# Number between 0 and 1 (0 = 0%, 0.5 = 50%, 1 = 100%)
+# Drop head percentage: chance to drop head, should be a number between 0 and 1: (0 = 0%, 0.5 = 50%, 1 = 100%)
+# Head name: name of the head whenever dropped from a player.
 drop-head-percentage: 0.5
+head-name: "&c%victim%'s Head"
 
-# Kill message cooldown to prevent spam: in seconds (0 = no cooldown)
+# Message cooldown: cooldown in seconds between death messages for a specific player. 0 to disable.
 message-cooldown: 0
 
 # Enable Global Messages: enables global death messages
 enable-global-messages: true
 
-# Original on Hover: Show the original death message when hovering over the custom message.
+# Original on Hover: show the original death message when hovering over the custom message.
 enable-original-on-hover: false
 
-# Item on Hover: Show the item used to kill the player when hovering over the item name.
+# Item on Hover: show the item used to kill the player when hovering over the item name.
 enable-item-on-hover: true
 
-# You can add messages or remove any of these messages. Toggleable by boolean above.
+# You can add, edit, or remove any of the messages below.
 # Placeholders for melee messages: %kill-weapon%, %victim%, %victim-nick%, %killer%, %killer-nick%, %killer-x%, %killer-y%, %killer-z%, %victim-x%, %victim-y%, %victim-z%
 global-pvp-death-messages:
   - "&c%victim% &ehas been killed by &c%killer%"
@@ -48,7 +46,7 @@ melee-death-messages:
   - "&c%victim% &ewas KO'd &c%killer%"
   - "&c%victim% &egot rocked by &c%killer%"
 
-# Messages for entities with custom names. Will override their mob group message and display these instead, if enabled.
+# Messages for entities with custom names: will override their mob group message and display these instead, if enabled.
 # Placeholders: %victim%, %victim-nick%, %entity-name%, %victim-x%, %victim-y%, %victim-z%
 enable-custom-name-entity-messages: true
 custom-name-entity-messages:

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -330,3 +330,6 @@ arrow-messages:
 
 # Only here to help me debug my plugin, not suggested you enable.
 developer-mode: false
+
+# Config version, do not change this.
+config-version: 2

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -19,18 +19,19 @@ do-lightning: true
 drop-head-percentage: 0.5
 
 # Kill message cooldown to prevent spam: in seconds (0 = no cooldown)
-kill-message-cooldown: 0
+message-cooldown: 0
 
 # Enable Global Messages: enables global death messages
 enable-global-messages: true
 
-# Original Hover Message: Show the original death message when hovering over the custom message.
-original-hover-message: false
+# Original on Hover: Show the original death message when hovering over the custom message.
+enable-original-on-hover: false
+
+# Item on Hover: Show the item used to kill the player when hovering over the item name.
+enable-item-on-hover: true
 
 # You can add messages or remove any of these messages. Toggleable by boolean above.
 # Placeholders for melee messages: %kill-weapon%, %victim%, %victim-nick%, %killer%, %killer-nick%, %killer-x%, %killer-y%, %killer-z%, %victim-x%, %victim-y%, %victim-z%
-# Enable Item Hover: When hovering over the kill-weapons name, it will display the items enchantments, etc.
-enable-item-hover: false
 global-pvp-death-messages:
   - "&c%victim% &ehas been killed by &c%killer%"
   - "&c%victim% &ewas slain by &c%killer% &eusing &7[&b%kill-weapon%&7]"
@@ -294,7 +295,7 @@ hoglin-messages:
 zoglin-messages:
   - "&c%victim% &eate a Zoglins horn for dinner"
   - "&c%victim% &ewas rammed by a Zoglin"
-  -
+
 goat-messages:
   - "&c%victim% &ewas headbutted by a Goat"
   - "&c%victim% &ewas impaled by a Goat horn"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -130,6 +130,11 @@ freeze-messages:
   - "&c%victim% &efroze to death. &b&lBrrrrr!"
   - "&c%victim% &eforgot his winter jacket"
 
+firework-messages:
+  - "&c%victim% &elit the fuse on a firework too soon"
+  - "&c%victim% &ewent out with a bang"
+  - "&c%victim% &eblasted off into space"
+
 slime-messages:
   - "&c%victim% &ewas crushed by a &a&lGIANT SLIME"
   - "&c%victim% &ewas slimed to death while collecting slime balls"

--- a/src/main/resources/config.yml
+++ b/src/main/resources/config.yml
@@ -52,7 +52,7 @@ enable-custom-name-entity-messages: true
 custom-name-entity-messages:
   - "&c%victim% &egot rocked by %entity-name%"
   - "&c%victim% &ewas put to sleep by %entity-name%"
-  - "%entity-name% &eate &c%victim%'s &esoul"
+  - "&c%entity-name% &eate &c%victim%'s &esoul"
   - "&c%victim% &ewishes they didn't fight %entity-name%"
 
 # Placeholders for ALL below messages: %victim%, %victim-nick%, %entity-name%, %victim-x%, %victim-y%, %victim-z%


### PR DESCRIPTION
# 2.0.1 Patch Notes

- Config now automatically updates itself without user intervention.
- Entity custom names will not be displayed if the entity has a heart in their name. Fixes McMMO health bar.
- Gave warden sonic booms their own message path in config.
- Added death message cooldowns
- Fixed items released after 1.13, such as netherite, triggering melee death messages.
- Fixed melee messages not being editable by the command.
- Fixed kill weapon placeholder not working if it was at the end of a death message.
- Future proofed plugin to prevent potential future incompatibilities.
- Other bug fixes.

Fixes #1 (first issue ever! and also very old)